### PR TITLE
feat: Coding solution

### DIFF
--- a/lib/src/challenge.dart
+++ b/lib/src/challenge.dart
@@ -1,20 +1,71 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 
-final class LiveCodingTest extends StatelessWidget {
-  final List<Widget> children;
+class LiveCodingTestParentData extends ContainerBoxParentData<RenderBox> {}
+
+class LiveCodingTest extends MultiChildRenderObjectWidget {
+  final Alignment alignment;
 
   const LiveCodingTest({
     super.key,
-    required this.children,
+    required super.children,
+    this.alignment = Alignment.center,
   });
 
   @override
-  Widget build(BuildContext context) {
-    return SizedBox.expand(
-      child: Stack(
-        alignment: Alignment.center,
-        children: children,
-      ),
-    );
+  RenderLiveCodingTest createRenderObject(BuildContext context) {
+    return RenderLiveCodingTest(alignment);
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderLiveCodingTest renderObject) {
+    renderObject.alignment = alignment;
+  }
+}
+
+class RenderLiveCodingTest extends RenderBox
+    with ContainerRenderObjectMixin<RenderBox, LiveCodingTestParentData>, RenderBoxContainerDefaultsMixin<RenderBox, LiveCodingTestParentData> {
+  Alignment alignment;
+
+  RenderLiveCodingTest(this.alignment);
+
+  /// Must be override to use [LiveCodingTestParentData]
+  @override
+  void setupParentData(RenderBox child) {
+    if (child.parentData is! LiveCodingTestParentData) {
+      child.parentData = LiveCodingTestParentData();
+    }
+  }
+
+  @override
+  void performLayout() {
+    // Layout children widgets to get their `Size` values.
+    RenderBox? child = firstChild;
+    while (child != null) {
+      final childParentData = child.parentData as LiveCodingTestParentData?;
+      child.layout(constraints.loosen(), parentUsesSize: true);
+      child = childParentData?.nextSibling;
+    }
+
+    // Position each child within the `RenderLiveCodingTest` size based on it's `constraints`
+    size = Size(constraints.maxWidth, constraints.maxHeight);
+    child = firstChild;
+    while (child != null) {
+      final childParentData = child.parentData as LiveCodingTestParentData?;
+      final dx = (size.width - child.size.width) / 2 * (alignment.x + 1);
+      final dy = (size.height - child.size.height) / 2 * (alignment.y + 1);
+      childParentData?.offset = Offset(dx, dy);
+      child = childParentData?.nextSibling;
+    }
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    RenderBox? child = firstChild;
+    while (child != null) {
+      final childParentData = child.parentData as LiveCodingTestParentData?;
+      context.paintChild(child, offset + (childParentData?.offset ?? Offset.zero));
+      child = childParentData?.nextSibling;
+    }
   }
 }

--- a/lib/src/challenge.dart
+++ b/lib/src/challenge.dart
@@ -25,6 +25,8 @@ class LiveCodingTest extends MultiChildRenderObjectWidget {
 
 class RenderLiveCodingTest extends RenderBox
     with ContainerRenderObjectMixin<RenderBox, LiveCodingTestParentData>, RenderBoxContainerDefaultsMixin<RenderBox, LiveCodingTestParentData> {
+  final _children = <RenderBox>[];
+
   Alignment alignment;
 
   RenderLiveCodingTest(this.alignment);
@@ -42,30 +44,35 @@ class RenderLiveCodingTest extends RenderBox
     // Layout children widgets to get their `Size` values.
     RenderBox? child = firstChild;
     while (child != null) {
+      _children.add(child);
       final childParentData = child.parentData as LiveCodingTestParentData?;
       child.layout(constraints.loosen(), parentUsesSize: true);
       child = childParentData?.nextSibling;
     }
 
-    // Position each child within the `RenderLiveCodingTest` size based on it's `constraints`
+    // Sort children by size
+    _children.sort((a, b) {
+      final sizeA = a.size;
+      final sizeB = b.size;
+
+      return (sizeB.width * sizeB.height).compareTo(sizeA.width * sizeA.height);
+    });
+
+    // Position each child within the `RenderLiveCodingTest` size based on `constraints`
     size = Size(constraints.maxWidth, constraints.maxHeight);
-    child = firstChild;
-    while (child != null) {
+    for (final child in _children) {
       final childParentData = child.parentData as LiveCodingTestParentData?;
       final dx = (size.width - child.size.width) / 2 * (alignment.x + 1);
       final dy = (size.height - child.size.height) / 2 * (alignment.y + 1);
       childParentData?.offset = Offset(dx, dy);
-      child = childParentData?.nextSibling;
     }
   }
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    RenderBox? child = firstChild;
-    while (child != null) {
+    for (final child in _children) {
       final childParentData = child.parentData as LiveCodingTestParentData?;
       context.paintChild(child, offset + (childParentData?.offset ?? Offset.zero));
-      child = childParentData?.nextSibling;
     }
   }
 }


### PR DESCRIPTION
### Changes
- Implemented a custom `Stack` widget using [MultiChildRenderObjectWidget](https://api.flutter.dev/flutter/widgets/MultiChildRenderObjectWidget-class.html) that sorts its children by size, displaying them from `the largest to the smallest`.

#### Image Preview
![image](https://github.com/user-attachments/assets/fce13a65-9ef7-4f2e-99ac-bd36d7f4df06)

---

### Personal Notes 
- **Common use case**: It is more common to use `MultiChildRenderObjectWidget` for `creating a custom layout`. Also, it is much easier to work with its implementation [CustomMultiChildLayout](https://api.flutter.dev/flutter/widgets/CustomMultiChildLayout-class.html) for creating a custom layout.
- **Performance**: In this implementation, the `MultiChildRenderObjectWidget` does not improve performance. `MultiChildRenderObjectWidget` can offer performance benefits in scenarios where not all child widgets need to be rendered, as we can skip the layout and painting processes for those widgets.
- **[RenderObject](https://api.flutter.dev/flutter/rendering/RenderObject-class.html) Widgets**:
    - [LeafRenderObjectWidget](https://api.flutter.dev/flutter/widgets/LeafRenderObjectWidget-class.html): No children (e.g., Text).
    - [SingleChildRenderObjectWidget](https://api.flutter.dev/flutter/widgets/SingleChildRenderObjectWidget-class.html): One child (e.g., Padding).
    - [MultiChildRenderObjectWidget] (https://api.flutter.dev/flutter/widgets/MultiChildRenderObjectWidget-class.html): Multiple children (e.g., Column). 
    - Understand `RenderObject` properties and methods to understand other render objects.
- `setupParentData` must be overridden to use custom `ParentData` (used by its parent to store layout-related information.) for child widgets in [performLayout] and [paint] methods.
```dart
  @override
  void setupParentData(RenderBox child) {
    if (child.parentData is! LiveCodingTestParentData) {
      child.parentData = LiveCodingTestParentData();
    }
  }
```