### PR TITLE
feat: Implement `generateRandomLiveCodingContainers` for `LiveCodingContainer` list generation

### DIFF
--- a/lib/src/app/home.dart
+++ b/lib/src/app/home.dart
@@ -1,32 +1,55 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:live_coding/src/app/container.dart';
 import 'package:live_coding/src/challenge.dart';
 
 final class LiveCodingHome extends StatelessWidget {
-  const LiveCodingHome({super.key});
-
-  static const _children = [
-    LiveCodingContainer(
-      dimension: 300,
-      color: Colors.red,
-    ),
-    LiveCodingContainer(
-      dimension: 200,
-      color: Colors.blue,
-    ),
-    LiveCodingContainer(
-      dimension: 100,
-      color: Colors.purple,
-    ),
+  static const _colors = [
+    Colors.red,
+    Colors.blue,
+    Colors.purple,
+    Colors.green,
+    Colors.orange,
+    Colors.yellow,
+    Colors.pink,
+    Colors.cyan,
+    Colors.brown,
+    Colors.grey,
+    Colors.teal,
+    Colors.indigo,
+    Colors.lime,
+    Colors.amber,
+    Colors.deepOrange,
+    Colors.deepPurple,
+    Colors.lightBlue,
+    Colors.lightGreen,
+    Colors.blueGrey,
+    Colors.black,
   ];
+
+  const LiveCodingHome({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final children = _children.toList();
     return Scaffold(
       body: LiveCodingTest(
-        children: children..shuffle(),
+        children: generateRandomLiveCodingContainers(5000).toList()..shuffle(),
       ),
     );
+  }
+
+  Iterable<LiveCodingContainer> generateRandomLiveCodingContainers(int n) sync* {
+    final random = Random();
+
+    for (int i = 0; i < n; i++) {
+      final dimension = 50 + random.nextInt(800);
+      final color = _colors[random.nextInt(_colors.length)];
+
+      yield LiveCodingContainer(
+        dimension: dimension.toDouble(),
+        color: color,
+      );
+    }
   }
 }


### PR DESCRIPTION
## Problem
When a large list of `LiveCodingContainer` widgets is provided to `LiveCodingTest`, there is a significant drop in UI performance. This is because `RenderLiveCodingTest` takes a considerable amount of time to process the layout, sort, and paint the widgets.

### Important Notes
1. **Non-Scrollable Page:**
   - The widgets are displayed on a non-scrollable page, so we can't implement lazy widget building for performance improvement.

2. **Synchronous `paint` and `performLayout` Methods:**
   - The `paint` and `performLayout` methods do not work asynchronously, so we cannot render one child at a time.
   - Flutter waits until all widgets are processed in these methods before rendering them on the page.
   - Attempting to refactor the code to be asynchronous, as shown below, did not render one child at a time:

```dart
@override
Future<void> paint(PaintingContext context, Offset offset) async {
  for (final child in _children) {
    await Future.delayed(Duration.zero);
    final childParentData = child.parentData as LiveCodingTestParentData?;
    context.paintChild(child, offset + (childParentData?.offset ?? Offset.zero));
  }
}
```

---

## Steps to Reproduce
1. Provide a large list of `LiveCodingContainer` widgets to the `LiveCodingTest` widget using the `generateRandomLiveCodingContainers` method.
2. Observe the performance drop during layout and rendering.

---

## Possible Solutions
1. **Remove Duplicate Sized Widgets:**
   - Eliminate widgets with identical sizes since they will overlap in the stack, making only one of them visible.
   - However, this solution might not significantly improve performance.